### PR TITLE
Feat/web extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This package helps you add authentication to your Single Page Application with K
 
 It's secure by design (using PKCE flow), easy to use, and works with any JavaScript framework.
 
+Since v1.6.0 it also supports web extensions through the `KobbleWebExtensionClient` class, more info available in our [documentation](https://docs.kobble.io).
+
 ## Getting Started
 
 ### Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.5.0",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",
+        "@types/chrome": "^0.0.268",
+        "@types/firefox-webext-browser": "^120.0.3",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.2",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
@@ -1657,10 +1659,41 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.268",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.268.tgz",
+      "integrity": "sha512-7N1QH9buudSJ7sI8Pe4mBHJr5oZ48s0hcanI9w3wgijAlv1OZNUZve9JR4x42dn5lJ5Sm87V1JNfnoh10EnQlA==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true
+    },
+    "node_modules/@types/firefox-webext-browser": {
+      "version": "120.0.3",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.3.tgz",
+      "integrity": "sha512-APbBSxOvFMbKwXy/4YrEVa5Di6N0C9yl4w0WA0xzdkOrChAfPQ/KlcC8QLyhemHCHpF1CB/zHy52+oUQurViOg==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -1671,6 +1704,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
+      "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
+    "@types/chrome": "^0.0.268",
+    "@types/firefox-webext-browser": "^120.0.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.2",
     "@typescript-eslint/eslint-plugin": "^7.4.0",

--- a/src/KobbleClient.ts
+++ b/src/KobbleClient.ts
@@ -101,11 +101,9 @@ export class KobbleClient {
 
     const scope = DEFAULT_SCOPE
 
-    const redirectUri = await this.getRedirectUri()
-
     const queryParams = createQueryParams({
       client_id: this.params.clientId,
-      redirect_uri: redirectUri,
+      redirect_uri: this.params.redirectUri,
       state: state,
       nonce: nonce,
       code_challenge: code_challenge,
@@ -121,15 +119,9 @@ export class KobbleClient {
       state,
       nonce,
       codeVerifier: code_verifier,
-      redirectUri: await this.getRedirectUri(),
+      redirectUri: this.params.redirectUri,
       scope
     }
-  }
-
-  private getRedirectUri() {
-    return typeof this.params.redirectUri === 'function'
-      ? this.params.redirectUri()
-      : this.params.redirectUri
   }
 
   private prepareTokenUrl() {

--- a/src/cache/LocalStorageCache.ts
+++ b/src/cache/LocalStorageCache.ts
@@ -1,4 +1,37 @@
 import type { CacheProvider, MaybePromise } from './common'
+import { getBrowser } from '../utils.ts'
+
+export class WebExtensionCache implements CacheProvider {
+  public set<T>(key: string, entry: T) {
+    const browser = getBrowser()
+
+    browser.storage.local.set({ [key]: JSON.stringify(entry) })
+  }
+
+  public async get<T>(key: string): Promise<T | undefined> {
+    const browser = getBrowser()
+
+    const items = await browser.storage.local.get(key)
+
+    if (!items[key]) return undefined
+
+    return JSON.parse(items[key])
+  }
+
+  public remove(key: string) {
+    const browser = getBrowser()
+
+    return browser.storage.local.remove(key)
+  }
+
+  public allKeys(prefix: string) {
+    const browser = getBrowser()
+
+    return browser.storage.local.get().then((items) => {
+      return Object.keys(items).filter((key) => key.startsWith(prefix))
+    })
+  }
+}
 
 export class LocalStorageCache implements CacheProvider {
   public set<T>(key: string, entry: T) {

--- a/src/global.ts
+++ b/src/global.ts
@@ -36,6 +36,35 @@ export interface RefreshTokenRequestTokenOptions {
   refresh_token: string
 }
 
+export type KobbleWebExtensionClientParams = {
+  /**
+   * This is the Base URL of your Kobble Customer Portal.
+   * To find it, go to your [Kobble Dashboard](https://app.kobble.io).
+   *
+   * Always use the root URL:
+   *
+   * DO: https://example.portal.kobble.io".
+   *
+   * DON'T: "https://example.portal.kobble.io/something".
+   */
+  domain: string
+  /**
+   * This is the client ID of your Kobble application.
+   * To find it, go to [Kobble Dashboard > Applications](https://app.kobble.io/p/applications)
+   * and click on your application or create a new one.
+   */
+  clientId: string
+  /**
+   * Do not change this parameter unless you know what you are doing.
+   */
+  sdkBaseUrl?: string
+  /**
+   * If true, the SDK will log more information to the console.
+   * This is useful for debugging but must be disabled in production.
+   */
+  verbose?: boolean
+}
+
 export type KobbleClientParams = {
   /**
    * This is the Base URL of your Kobble Customer Portal.
@@ -62,7 +91,7 @@ export type KobbleClientParams = {
    * You can use the <HandleCallback /> component to easily handle the callback.
    * [See the docs](https://docs.kobble.io/learning/quickstart/react).
    */
-  redirectUri: string
+  redirectUri: string | (() => Promise<string> | string)
   /**
    * Do not change this parameter unless you know what you are doing.
    */

--- a/src/global.ts
+++ b/src/global.ts
@@ -91,7 +91,7 @@ export type KobbleClientParams = {
    * You can use the <HandleCallback /> component to easily handle the callback.
    * [See the docs](https://docs.kobble.io/learning/quickstart/react).
    */
-  redirectUri: string | (() => Promise<string> | string)
+  redirectUri: string
   /**
    * Do not change this parameter unless you know what you are doing.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,17 @@
 import { KobbleClient } from './KobbleClient'
-import { KobbleClientParams } from './global'
+import { KobbleWebExtensionClient } from './KobbleWebExtensionClient.ts'
+import { KobbleClientParams, KobbleWebExtensionClientParams } from './global'
 
 export const createKobbleClient = (params: KobbleClientParams): KobbleClient => {
   return new KobbleClient(params)
 }
 
+export const createKobbleWebExtensionClient = (params: KobbleWebExtensionClientParams) => {
+  return new KobbleWebExtensionClient(params)
+}
+
 export * from './access-control/types.ts'
 export * from './global'
 export { KobbleClient } from './KobbleClient'
+
+export { KobbleWebExtensionClient } from './KobbleWebExtensionClient'

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -4,6 +4,22 @@ export interface ClientStorage {
   removeItem(key: string): void
 }
 
+export class WebExtSessionStorage implements ClientStorage {
+  private storage: Record<string, unknown> = {}
+
+  getItem(key: string): object | null {
+    return this.storage[key] ?? null
+  }
+
+  setItem(key: string, value: object) {
+    this.storage[key] = value
+  }
+
+  removeItem(key: string) {
+    delete this.storage[key]
+  }
+}
+
 export const SessionStorage = {
   getItem(key: string): object | null {
     if (!sessionStorage) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,19 +10,31 @@ export const generateRandomString = () => {
   return random
 }
 
+export const getBrowser = (): typeof browser | typeof chrome => {
+  if (typeof browser !== 'undefined') {
+    return browser
+  }
+
+  if (typeof chrome === 'undefined') {
+    throw new Error(
+      'Cannot find the browser or the chrome object. Make sure you are running in a web extension environment?'
+    )
+  }
+
+  return chrome
+}
+
 export const encode = (value: string) => btoa(value)
 export const decode = (value: string) => atob(value)
 
 export const getCrypto = () => {
-  if (!window) {
-    throw new Error('KobbleClient must be run in a browser environment.')
+  if (!crypto) {
+    throw new Error(
+      'KobbleClient requires crypto API to be available for security reasons. Are you running in a browser?'
+    )
   }
 
-  if (!window.crypto) {
-    throw new Error('KobbleClient requires window.crypto to be available for security reasons.')
-  }
-
-  return window.crypto
+  return crypto
 }
 
 export const sha256 = async (s: string) => {
@@ -51,7 +63,7 @@ const urlEncodeB64 = (input: string) => {
 
 export const bufferToBase64UrlEncoded = (input: ArrayBuffer) => {
   const ie11SafeInput = new Uint8Array(input)
-  return urlEncodeB64(window.btoa(String.fromCharCode(...Array.from(ie11SafeInput))))
+  return urlEncodeB64(btoa(String.fromCharCode(...Array.from(ie11SafeInput))))
 }
 
 const clearUndefined = (params: Record<any, any>) => {


### PR DESCRIPTION
Add support for web extensions through the KobbleWebExtensionClient class.

```ts
import { KobbleWebExtensionClient } from '@kobbleio/javascript';

const client = new KobbleWebExtensionClient({ ... })
```

The `KobbleWebExtensionClient` interface is almost identical to the classic KobbleClient, but there is a difference in the way the `loginWithRedirect` method works.

In a web extension, `loginWithRedirect` handles the callback URL on its own, so now callback page is required anymore.

Implementation-wise, everything related to storage and cache implements the same interfaces but with different classes that are adapted to the web extension runtime.